### PR TITLE
Format output filenames to 3-digit zero-pad.

### DIFF
--- a/split-appended-dtb.c
+++ b/split-appended-dtb.c
@@ -130,7 +130,7 @@ int split(char *kernel_image)
             len = dtb_next - dtb_head;
 
         // Dump found dtbs
-        sprintf(outfile, "dtbdump_%d.dtb", ++dtb_count);
+        sprintf(outfile, "dtbdump_%03d.dtb", ++dtb_count);
         fp = fopen(outfile, "wb");
         rc = dump_file(fp, dtb_head, len);
         fclose(fp);


### PR DESCRIPTION
The idea is to make it easier for the user to see all dtb files in the order they came from the image and make it easier to parse.